### PR TITLE
Update pre-commit workflow: use Python 3.12 and pin pre-commit to 4.5.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
       - name: Install pre-commit
-        run: python -m pip install --upgrade pip pre-commit
+        run: python -m pip install --upgrade pip "pre-commit==4.5.1"
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files


### PR DESCRIPTION
### Motivation
- Ensure CI uses a consistent, modern Python runtime and a reproducible `pre-commit` version to avoid differences between runners and unexpected breakage.

### Description
- In `.github/workflows/pre-commit.yml` set `python-version` to `3.12` and pin the `pre-commit` package to `4.5.1` when installing via `pip`.

### Testing
- No automated test runs were executed as part of this change; the GitHub Actions `pre-commit` job will run `pre-commit run --all-files` on the next push or pull request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd4df0b2083228d6e002364f4a5d6)